### PR TITLE
Add query property

### DIFF
--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -141,6 +141,10 @@ class QueryEvent(BinLogEvent):
         print("Execution time: %d" % (self.execution_time))
         print("Query: %s" % (self.query))
 
+   @property
+   def query(self):
+	retrun self.query
+
 
 class NotImplementedEvent(BinLogEvent):
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -141,8 +141,8 @@ class QueryEvent(BinLogEvent):
         print("Execution time: %d" % (self.execution_time))
         print("Query: %s" % (self.query))
 
-   @property
-   def query(self):
+    @property
+    def query(self):
 	retrun self.query
 
 

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -143,7 +143,7 @@ class QueryEvent(BinLogEvent):
 
     @property
     def query(self):
-	retrun self.query
+	return self.query
 
 
 class NotImplementedEvent(BinLogEvent):


### PR DESCRIPTION
I am trying to do unit test with 
mock_query_event = mock.Mock(spec=QueryEvent)
it would not let me use mock_query_event.query, so I am suggesting that we turn it into a property!

Thanks!
