### PR TITLE
add support for StopEvent

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -8,11 +8,11 @@ from pymysql.cursors import DictCursor
 from pymysql.util import int2byte
 
 from .packet import BinLogPacketWrapper
-from .constants.BINLOG import TABLE_MAP_EVENT, ROTATE_EVENT
+from .constants.BINLOG import TABLE_MAP_EVENT, ROTATE_EVENT, STOP_EVENT
 from .gtid import GtidSet
 from .event import (
     QueryEvent, RotateEvent, FormatDescriptionEvent,
-    XidEvent, GtidEvent, NotImplementedEvent)
+    XidEvent, GtidEvent, StopEvent, NotImplementedEvent)
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
 
@@ -66,10 +66,7 @@ class BinLogStreamReader(object):
         self.__allowed_events = self._allowed_event_list(
             only_events, ignored_events, filter_non_implemented_events)
 
-        # We can't filter on packet level TABLE_MAP and rotate event because
-        # we need them for handling other operations
-        self.__allowed_events_in_packet = frozenset(
-            [TableMapEvent, RotateEvent]).union(self.__allowed_events)
+        self.__allowed_events_in_packet = self.__allowed_events
 
         self.__server_id = server_id
         self.__use_checksum = False
@@ -292,6 +289,7 @@ class BinLogStreamReader(object):
             events = set((
                 QueryEvent,
                 RotateEvent,
+                StopEvent,
                 FormatDescriptionEvent,
                 XidEvent,
                 GtidEvent,

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -95,6 +95,10 @@ class FormatDescriptionEvent(BinLogEvent):
     pass
 
 
+class StopEvent(BinLogEvent):
+    pass
+
+
 class XidEvent(BinLogEvent):
     """A COMMIT event
 

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -33,7 +33,7 @@ class BinLogPacketWrapper(object):
         constants.XID_EVENT: event.XidEvent,
         constants.INTVAR_EVENT: event.NotImplementedEvent,
         constants.GTID_LOG_EVENT: event.GtidEvent,
-        constants.STOP_EVENT: event.NotImplementedEvent,
+        constants.STOP_EVENT: event.StopEvent,
         # row_event
         constants.UPDATE_ROWS_EVENT_V1: row_event.UpdateRowsEvent,
         constants.WRITE_ROWS_EVENT_V1: row_event.WriteRowsEvent,


### PR DESCRIPTION
Also, there's no need to readd 'TableMapEvent', 'RotateEvent' which are already contained in `__allowed_events`.