### PR TITLE
skipping GTID tests on DBs not set up to support GTID

### DIFF
--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -55,6 +55,12 @@ class PyMySQLReplicationTestCase(base):
             return True
         return False
 
+    @property
+    def supportsGTID(self):
+        if not self.isMySQL56AndMore():
+            return False
+        return self.execute("SELECT @@global.gtid_mode ").fetchone()[0] == "ON"
+
     def connect_conn_control(self, db):
         if self.conn_control is not None:
             self.conn_control.close()

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import unittest
 
 from pymysqlreplication.tests import base
 from pymysqlreplication import BinLogStreamReader
@@ -542,6 +543,11 @@ class TestMultipleRowBinLogStreamReader(base.PyMySQLReplicationTestCase):
 
 
 class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
+    def setUp(self):
+        super(TestGtidBinLogStreamReader, self).setUp()
+        if not self.supportsGTID:
+            raise unittest.SkipTest("database does not support GTID, skipping GTID tests")
+
     def test_read_query_event(self):
         query = "CREATE TABLE test (id INT NOT NULL, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
         self.execute(query)


### PR DESCRIPTION
It's been painful debugging unittests on DB which doesn't support GTID either because it's MySQL older than 5.6 or because it `gtid_mode` is set to OFF. This should help. 
