### PR TITLE
Column attributes as regular attributes instead of a dict

### DIFF
--- a/pymysqlreplication/column.py
+++ b/pymysqlreplication/column.py
@@ -10,76 +10,75 @@ class Column(object):
     """
 
     def __init__(self, *args, **kwargs):
-        self.data = {}
         if len(args) == 3:
             self.__parse_column_definition(*args)
         else:
-            self.data = kwargs
+            self.__dict__.update(kwargs)
 
     def __parse_column_definition(self, column_type, column_schema, packet):
-        self.data["type"] = column_type
-        self.data["name"] = column_schema["COLUMN_NAME"]
-        self.data["collation_name"] = column_schema["COLLATION_NAME"]
-        self.data["character_set_name"] = column_schema["CHARACTER_SET_NAME"]
-        self.data["comment"] = column_schema["COLUMN_COMMENT"]
-        self.data["unsigned"] = False
-        self.data["type_is_bool"] = False
+        self.type = column_type
+        self.name = column_schema["COLUMN_NAME"]
+        self.collation_name = column_schema["COLLATION_NAME"]
+        self.character_set_name = column_schema["CHARACTER_SET_NAME"]
+        self.comment = column_schema["COLUMN_COMMENT"]
+        self.unsigned = False
+        self.type_is_bool = False
         if column_schema["COLUMN_KEY"] == "PRI":
-            self.data["is_primary"] = True
+            self.is_primary = True
         else:
-            self.data["is_primary"] = False
+            self.is_primary = False
 
         if column_schema["COLUMN_TYPE"].find("unsigned") != -1:
-            self.data["unsigned"] = True
+            self.unsigned = True
         if self.type == FIELD_TYPE.VAR_STRING or \
                 self.type == FIELD_TYPE.STRING:
             self.__read_string_metadata(packet, column_schema)
         elif self.type == FIELD_TYPE.VARCHAR:
-            self.data["max_length"] = struct.unpack('<H', packet.read(2))[0]
+            self.max_length = struct.unpack('<H', packet.read(2))[0]
         elif self.type == FIELD_TYPE.BLOB:
-            self.data["length_size"] = packet.read_uint8()
+            self.length_size = packet.read_uint8()
         elif self.type == FIELD_TYPE.GEOMETRY:
-            self.data["length_size"] = packet.read_uint8()
+            self.length_size = packet.read_uint8()
         elif self.type == FIELD_TYPE.NEWDECIMAL:
-            self.data["precision"] = packet.read_uint8()
-            self.data["decimals"] = packet.read_uint8()
+            self.precision = packet.read_uint8()
+            self.decimals = packet.read_uint8()
         elif self.type == FIELD_TYPE.DOUBLE:
-            self.data["size"] = packet.read_uint8()
+            self.size = packet.read_uint8()
         elif self.type == FIELD_TYPE.FLOAT:
-            self.data["size"] = packet.read_uint8()
+            self.size = packet.read_uint8()
         elif self.type == FIELD_TYPE.BIT:
             bits = packet.read_uint8()
             bytes = packet.read_uint8()
-            self.data["bits"] = (bytes * 8) + bits
-            self.data["bytes"] = int((self.bits + 7) / 8)
+            self.bits = (bytes * 8) + bits
+            self.bytes = int((self.bits + 7) / 8)
         elif self.type == FIELD_TYPE.TIMESTAMP2:
-            self.data["fsp"] = packet.read_uint8()
+            self.fsp = packet.read_uint8()
         elif self.type == FIELD_TYPE.DATETIME2:
-            self.data["fsp"] = packet.read_uint8()
+            self.fsp = packet.read_uint8()
         elif self.type == FIELD_TYPE.TIME2:
-            self.data["fsp"] = packet.read_uint8()
+            self.fsp = packet.read_uint8()
         elif self.type == FIELD_TYPE.TINY and \
                 column_schema["COLUMN_TYPE"] == "tinyint(1)":
-            self.data["type_is_bool"] = True
+            self.type_is_bool = True
 
     def __read_string_metadata(self, packet, column_schema):
         metadata = (packet.read_uint8() << 8) + packet.read_uint8()
         real_type = metadata >> 8
         if real_type == FIELD_TYPE.SET or real_type == FIELD_TYPE.ENUM:
-            self.data["type"] = real_type
-            self.data["size"] = metadata & 0x00ff
+            self.type = real_type
+            self.size = metadata & 0x00ff
             self.__read_enum_metadata(column_schema)
         else:
-            self.data["max_length"] = (((metadata >> 4) & 0x300) ^ 0x300) \
+            self.max_length = (((metadata >> 4) & 0x300) ^ 0x300) \
                 + (metadata & 0x00ff)
 
     def __read_enum_metadata(self, column_schema):
         enums = column_schema["COLUMN_TYPE"]
         if self.type == FIELD_TYPE.ENUM:
-            self.data["enum_values"] = enums.replace('enum(', '')\
+            self.enum_values = enums.replace('enum(', '')\
                 .replace(')', '').replace('\'', '').split(',')
         else:
-            self.data["set_values"] = enums.replace('set(', '')\
+            self.set_values = enums.replace('set(', '')\
                 .replace(')', '').replace('\'', '').split(',')
 
     def __eq__(self, other):
@@ -89,10 +88,8 @@ class Column(object):
         return not self.__eq__(other)
 
     def serializable_data(self):
-        return self.data
+        return dict((k, v) for (k, v) in self.__dict__.items() if not k.startswith('_'))
 
-    def __getattr__(self, item):
-        try:
-            return self.data[item]
-        except KeyError:
-            raise AttributeError("{0} not found".format(item))
+    @property
+    def data(self):
+        return self.serializable_data()

--- a/pymysqlreplication/column.py
+++ b/pymysqlreplication/column.py
@@ -83,8 +83,8 @@ class Column(object):
         return not self.__eq__(other)
 
     def serializable_data(self):
-        return dict((k, v) for (k, v) in self.__dict__.items() if not k.startswith('_'))
+        return self.data
 
     @property
     def data(self):
-        return self.serializable_data()
+        return dict((k, v) for (k, v) in self.__dict__.items() if not k.startswith('_'))

--- a/pymysqlreplication/column.py
+++ b/pymysqlreplication/column.py
@@ -21,36 +21,16 @@ class Column(object):
         self.collation_name = column_schema["COLLATION_NAME"]
         self.character_set_name = column_schema["CHARACTER_SET_NAME"]
         self.comment = column_schema["COLUMN_COMMENT"]
-        self.unsigned = False
+        self.unsigned = column_schema["COLUMN_TYPE"].find("unsigned") != -1
         self.type_is_bool = False
-        if column_schema["COLUMN_KEY"] == "PRI":
-            self.is_primary = True
-        else:
-            self.is_primary = False
+        self.is_primary = column_schema["COLUMN_KEY"] == "PRI"
 
-        if column_schema["COLUMN_TYPE"].find("unsigned") != -1:
-            self.unsigned = True
-        if self.type == FIELD_TYPE.VAR_STRING or \
-                self.type == FIELD_TYPE.STRING:
-            self.__read_string_metadata(packet, column_schema)
-        elif self.type == FIELD_TYPE.VARCHAR:
+        if self.type == FIELD_TYPE.VARCHAR:
             self.max_length = struct.unpack('<H', packet.read(2))[0]
-        elif self.type == FIELD_TYPE.BLOB:
-            self.length_size = packet.read_uint8()
-        elif self.type == FIELD_TYPE.GEOMETRY:
-            self.length_size = packet.read_uint8()
-        elif self.type == FIELD_TYPE.NEWDECIMAL:
-            self.precision = packet.read_uint8()
-            self.decimals = packet.read_uint8()
         elif self.type == FIELD_TYPE.DOUBLE:
             self.size = packet.read_uint8()
         elif self.type == FIELD_TYPE.FLOAT:
             self.size = packet.read_uint8()
-        elif self.type == FIELD_TYPE.BIT:
-            bits = packet.read_uint8()
-            bytes = packet.read_uint8()
-            self.bits = (bytes * 8) + bits
-            self.bytes = int((self.bits + 7) / 8)
         elif self.type == FIELD_TYPE.TIMESTAMP2:
             self.fsp = packet.read_uint8()
         elif self.type == FIELD_TYPE.DATETIME2:
@@ -60,6 +40,21 @@ class Column(object):
         elif self.type == FIELD_TYPE.TINY and \
                 column_schema["COLUMN_TYPE"] == "tinyint(1)":
             self.type_is_bool = True
+        elif self.type == FIELD_TYPE.VAR_STRING or \
+                self.type == FIELD_TYPE.STRING:
+            self.__read_string_metadata(packet, column_schema)
+        elif self.type == FIELD_TYPE.BLOB:
+            self.length_size = packet.read_uint8()
+        elif self.type == FIELD_TYPE.GEOMETRY:
+            self.length_size = packet.read_uint8()
+        elif self.type == FIELD_TYPE.NEWDECIMAL:
+            self.precision = packet.read_uint8()
+            self.decimals = packet.read_uint8()
+        elif self.type == FIELD_TYPE.BIT:
+            bits = packet.read_uint8()
+            bytes = packet.read_uint8()
+            self.bits = (bytes * 8) + bits
+            self.bytes = int((self.bits + 7) / 8)
 
     def __read_string_metadata(self, packet, column_schema):
         metadata = (packet.read_uint8() << 8) + packet.read_uint8()

--- a/pymysqlreplication/table.py
+++ b/pymysqlreplication/table.py
@@ -2,7 +2,7 @@
 
 
 class Table(object):
-    def __init__(self, column_schemas, table_id, schema, table, columns, primary_key = None):
+    def __init__(self, column_schemas, table_id, schema, table, columns, primary_key=None):
         if primary_key is None:
             primary_key = [c.data["name"] for c in columns if c.data["is_primary"]]
             if len(primary_key) == 0:
@@ -12,26 +12,24 @@ class Table(object):
             else:
                 primary_key = tuple(primary_key)
 
-        self.data = {
+        self.__dict__.update({
             "column_schemas": column_schemas,
             "table_id": table_id,
             "schema": schema,
             "table": table,
             "columns": columns,
             "primary_key": primary_key
-        }
+        })
 
-    def __getattr__(self, item):
-        try:
-            return self.data[item]
-        except KeyError:
-            raise AttributeError
+    @property
+    def data(self):
+        return dict((k, v) for (k, v) in self.__dict__.items() if not k.startswith('_'))
 
     def __eq__(self, other):
         return self.data == other.data
 
     def __ne__(self, other):
-        return self.__eq__(other)
+        return not self.__eq__(other)
 
     def serializable_data(self):
         return self.data


### PR DESCRIPTION
Making Column attributes into regular object attributes instead of a dictionary.

This makes getting the attribute about 20 times faster.

Rationale behind this is the fact that 15% of time spent on creating and using
`RowsEvent` was spent on `Column.__getattr__`. 

There is more to be optimized, but this one was a low hanging fruit.