### PR TITLE
Explicit close stream connection on exception

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -244,6 +244,7 @@ class BinLogStreamReader(object):
             except pymysql.OperationalError as error:
                 code, message = error.args
                 if code in MYSQL_EXPECTED_ERROR_CODES:
+                    self._stream_connection.close()
                     self.__connected_stream = False
                     continue
 


### PR DESCRIPTION
Issue https://github.com/noplay/python-mysql-replication/issues/121 for details.
This change helps with PyPy, which does not seem to close the socket automatically on exception, leaving a socket in CLOSE_WAIT for each disconnection until the program is terminated.