### PR TITLE
Fix GtidSet __str__ representation

### DIFF
--- a/pymysqlreplication/gtid.py
+++ b/pymysqlreplication/gtid.py
@@ -88,7 +88,7 @@ class GtidSet(object):
             self.gtids = [Gtid(x) for x in gtid_set.split(',')]
 
     def __str__(self):
-        return ','.join(repr(x) for x in self.gtids)
+        return ','.join(str(x) for x in self.gtids)
 
     def __repr__(self):
         return '<GtidSet "%s"' % ','.join(repr(x) for x in self.gtids)

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -8,6 +8,7 @@ else:
 
 from pymysqlreplication.tests import base
 from pymysqlreplication import BinLogStreamReader
+from pymysqlreplication.gtid import GtidSet
 from pymysqlreplication.event import *
 from pymysqlreplication.constants.BINLOG import *
 from pymysqlreplication.row_event import *
@@ -694,6 +695,15 @@ class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
         event = self.stream.fetchone()
 
         self.assertEqual(event.query, 'CREATE TABLE test2 (id INT NOT NULL, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))');
+
+
+class TestGtidRepresentation(unittest.TestCase):
+    def test_gtidset_representation(self):
+        set_repr = '57b70f4e-20d3-11e5-a393-4a63946f7eac:1-56,' \
+                   '4350f323-7565-4e59-8763-4b1b83a0ce0e:1-20'
+
+        myset = GtidSet(set_repr)
+        self.assertEqual(str(myset), set_repr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Gtid str representation is built from the str of their gtid, and not their repr