### PR TITLE
bugfix for decoding values of columns in charset "utf8mb4"

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -5,6 +5,7 @@ import decimal
 import datetime
 
 from pymysql.util import byte2int
+from pymysql.charset import charset_to_encoding
 
 from .event import BinLogEvent
 from .constants import FIELD_TYPE
@@ -194,7 +195,7 @@ class RowsEvent(BinLogEvent):
     def __read_string(self, size, column):
         string = self.packet.read_length_coded_pascal_string(size)
         if column.character_set_name is not None:
-            string = string.decode(column.character_set_name)
+            string = string.decode(charset_to_encoding(column.character_set_name))
         return string
 
     def __read_bit(self, column):


### PR DESCRIPTION
Python would throw an exception for decoding values of columns in charset "utf8mb4", as there is no such encoding "utf8mb4" in python, but just "utf8".