### PR TITLE
fix: missing update _next_seq_no

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -226,6 +226,7 @@ class BinLogStreamReader(object):
             self._stream_connection.wfile.flush()
         else:
             self._stream_connection._write_bytes(prelude)
+            self._stream_connection._next_seq_id = 1
         self.__connected_stream = True
 
     def fetchone(self):


### PR DESCRIPTION
Missing update _next_seq_no after write raw packet. 

Error traceback:

```
$ python dump_events.py
Traceback (most recent call last):
  File "dump_events.py", line 36, in <module>
    main()
  File "dump_events.py", line 27, in main
    for binlogevent in stream:
  File "/data/users/xiezhenye/truck/pymysqlreplication/binlogstream.py", line 244, in fetchone
    pkt = self._stream_connection._read_packet()
  File "/data/users/xiezhenye/truck/pymysql/connections.py", line 952, in _read_packet
    (packet_number, self._next_seq_id))
pymysql.err.InternalError: Packet sequence number wrong - got 1 expected 10
```