### PR TITLE
gtid: fixup parsing on mysql format

### DIFF
--- a/pymysqlreplication/gtid.py
+++ b/pymysqlreplication/gtid.py
@@ -85,7 +85,7 @@ class GtidSet(object):
         if not gtid_set:
             self.gtids = []
         else:
-            self.gtids = [Gtid(x) for x in gtid_set.split(',')]
+            self.gtids = [Gtid(x.strip(' \n')) for x in gtid_set.split(',')]
 
     def __str__(self):
         return ','.join(str(x) for x in self.gtids)

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -705,6 +705,15 @@ class TestGtidRepresentation(unittest.TestCase):
         myset = GtidSet(set_repr)
         self.assertEqual(str(myset), set_repr)
 
+    def test_gtidset_representation_newline(self):
+        set_repr = '57b70f4e-20d3-11e5-a393-4a63946f7eac:1-56,' \
+                   '4350f323-7565-4e59-8763-4b1b83a0ce0e:1-20'
+        mysql_repr = '57b70f4e-20d3-11e5-a393-4a63946f7eac:1-56,\n' \
+                   '4350f323-7565-4e59-8763-4b1b83a0ce0e:1-20'
+
+        myset = GtidSet(mysql_repr)
+        self.assertEqual(str(myset), set_repr)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
Mysql may return gtid joined by ',\n' separator:
 SELECT @@global.gtid_executed