### PR TITLE
Enabling IntvarEvents and master server validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ from pymysqlreplication import BinLogStreamReader
 
 mysql_settings = {'host': '127.0.0.1', 'port': 3306, 'user': 'root', 'passwd': ''}
 
-stream = BinLogStreamReader(connection_settings = mysql_settings)
+stream = BinLogStreamReader(connection_settings = mysql_settings, server_id=2)
 
 for binlogevent in stream:
     binlogevent.dump()
@@ -322,5 +322,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -470,7 +470,6 @@ class BinLogStreamReader(object):
             except pymysql.OperationalError as error:
                 code, message = error.args
                 if code in MYSQL_EXPECTED_ERROR_CODES:
-                    self._stream_connection.close()
                     self.__connected_ctl = False
                     continue
                 else:


### PR DESCRIPTION
- Enable parsing intvar events
- Verifies that the informed mysql server is properly configured as master