### PR TITLE
setup travis to run test on multiple mysql version (5.6 and 5.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,56 +5,16 @@ python:
   - "3.3"
   - "3.4"
   - "pypy"
+env:
+  - DB=mysql57
+  - DB=mysql56
 install:
-    - "pip install ."
-    - "pip install nose"
+  - "pip install ."
+  - "pip install nose"
 cache: apt
 before_script:
-  # Remove old mysql version
-  - "sudo /etc/init.d/mysql stop || true"   
-  - "sudo apt-get remove mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5 mysql-client-core-5.5"
-  - "sudo apt-get autoremove"
-  # Config
-  - "sudo sed -i'' 's/table_cache/table_open_cache/' /etc/mysql/my.cnf"
-  - "sudo sed -i'' 's/log_slow_queries/slow_query_log/' /etc/mysql/my.cnf"
-
-  # Install new mysql version
-  - "echo deb http://repo.mysql.com/apt/ubuntu/ precise mysql-5.6 | sudo tee /etc/apt/sources.list.d/mysql.list"
-  - "sudo apt-key add .mysql/dev.mysql.com.gpg.key"
-  - "sudo apt-get update"
-  - "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::='--force-confold' -q -y mysql-server"
-
-  # Cleanup old mysql datas
-  - "sudo rm -rf /var/ramfs/mysql/"
-  - "sudo mkdir /var/ramfs/mysql/"
-  - "sudo chown mysql: /var/ramfs/mysql/"
-
-  # Config
-  - "echo '[mysqld]'            | sudo tee /etc/mysql/conf.d/replication.cnf"
-  - "echo 'log-bin=mysql-bin'   | sudo tee -a /etc/mysql/conf.d/replication.cnf"
-  - "echo 'server-id=1'         | sudo tee -a /etc/mysql/conf.d/replication.cnf"
-  - "echo 'binlog-format = row' | sudo tee -a /etc/mysql/conf.d/replication.cnf"
- 
-  - "sudo /etc/init.d/mysql stop || true" 
-
-  # Install new datas
-  - "sudo mysql_install_db --defaults-file=/etc/mysql/my.cnf --basedir=/usr --datadir=/var/ramfs/mysql --verbose"
-
-  # Enable GTID
-  - "echo '[mysqld]'                       | sudo tee /etc/mysql/conf.d/gtid.cnf"
-  - "echo 'gtid_mode=ON'                   | sudo tee -a /etc/mysql/conf.d/gtid.cnf"
-  - "echo 'enforce_gtid_consistency'       | sudo tee -a /etc/mysql/conf.d/gtid.cnf"
-  - "echo 'binlog_format=ROW'              | sudo tee -a /etc/mysql/conf.d/gtid.cnf"
-  - "echo 'log_slave_updates'              | sudo tee -a /etc/mysql/conf.d/gtid.cnf"
-
-  # Start mysql (avoid errors to have logs)
-  - "sudo /etc/init.d/mysql start || true"
-  - "sudo tail -1000 /var/log/syslog"
-
-  - "mysql --version"
-  - "mysql -e 'SELECT VERSION();'"
-  - "mysql -u root -e \"GRANT ALL PRIVILEGES ON *.* TO ''@'localhost';\""
-
-  - "mysql -e 'CREATE DATABASE pymysqlreplication_test;'"
+  - env | grep DB
+  - bash -c "if [ '$DB' = 'mysql57' ]; then sudo ./scripts/install_mysql_sandbox.sh; ./scripts/install_mysql57_on_sandbox.sh; fi"
+  - bash -c "if [ '$DB' = 'mysql56' ]; then sudo ./scripts/install_mysql56.sh; fi"
 script:
   - "nosetests"

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -19,17 +19,32 @@ class PyMySQLReplicationTestCase(base):
         return []
 
     def setUp(self):
-        self.database = {
-            "host": "localhost",
-            "user": "root",
-            "passwd": "",
-            "port": 3306,
-            "use_unicode": True,
-            "charset": "utf8",
-            "db": "pymysqlreplication_test"
-        }
-        if os.getenv("TRAVIS") is not None:
-            self.database["user"] = "travis"
+
+        db = os.environ.get('DB')
+        if db == 'mysql57':
+            # mysql 5.7 sandbox running on travis
+            self.database = {
+                "host": "localhost",
+                "user": "root",
+                "passwd": "msandbox",
+                "port": 5712,
+                "use_unicode": True,
+                "charset": "utf8",
+                "db": "pymysqlreplication_test"
+            }
+        else:
+            # default
+            self.database = {
+                "host": "localhost",
+                "user": "root",
+                "passwd": "",
+                "port": 3306,
+                "use_unicode": True,
+                "charset": "utf8",
+                "db": "pymysqlreplication_test"
+            }
+            if os.getenv("TRAVIS") is not None:
+                self.database["user"] = "travis"
 
         self.conn_control = None
         db = copy.copy(self.database)

--- a/scripts/install_mysql56.sh
+++ b/scripts/install_mysql56.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Remove old mysql version
+/etc/init.d/mysql stop || true
+apt-get remove mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5 mysql-client-core-5.5
+apt-get autoremove
+
+# Config
+sed -i'' 's/table_cache/table_open_cache/' /etc/mysql/my.cnf
+sed -i'' 's/log_slow_queries/slow_query_log/' /etc/mysql/my.cnf
+
+# Install new mysql version
+echo deb http://repo.mysql.com/apt/ubuntu/ precise mysql-5.6 | tee /etc/apt/sources.list.d/mysql.list
+apt-key add .mysql/dev.mysql.com.gpg.key
+apt-get update
+env DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::='--force-confold' -q -y mysql-server
+
+# Cleanup old mysql datas
+rm -rf /var/ramfs/mysql/
+mkdir /var/ramfs/mysql/
+chown mysql: /var/ramfs/mysql/
+
+# Config
+echo '[mysqld]'            | tee /etc/mysql/conf.d/replication.cnf
+echo 'log-bin=mysql-bin'   | tee -a /etc/mysql/conf.d/replication.cnf
+echo 'server-id=1'         | tee -a /etc/mysql/conf.d/replication.cnf
+echo 'binlog-format = row' | tee -a /etc/mysql/conf.d/replication.cnf
+
+/etc/init.d/mysql stop || true
+
+# Install new datas
+mysql_install_db --defaults-file=/etc/mysql/my.cnf --basedir=/usr --datadir=/var/ramfs/mysql --verbose
+
+# Enable GTID
+echo '[mysqld]'                       | tee /etc/mysql/conf.d/gtid.cnf
+echo 'gtid_mode=ON'                   | tee -a /etc/mysql/conf.d/gtid.cnf
+echo 'enforce_gtid_consistency'       | tee -a /etc/mysql/conf.d/gtid.cnf
+echo 'binlog_format=ROW'              | tee -a /etc/mysql/conf.d/gtid.cnf
+echo 'log_slave_updates'              | tee -a /etc/mysql/conf.d/gtid.cnf
+
+# Start mysql (avoid errors to have logs)
+/etc/init.d/mysql start || true
+tail -1000 /var/log/syslog
+
+mysql --version
+mysql -e 'SELECT VERSION();'
+mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO ''@'localhost';"
+
+mysql -e 'CREATE DATABASE pymysqlreplication_test;'

--- a/scripts/install_mysql57_on_sandbox.sh
+++ b/scripts/install_mysql57_on_sandbox.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+mkdir $HOME/bins
+mkdir $HOME/sandboxes
+
+cd $HOME/bins
+curl -O http://cdn.mysql.com//Downloads/MySQL-5.7/mysql-5.7.12-linux-glibc2.5-x86_64.tar.gz
+tar xfz mysql-5.7.12-linux-glibc2.5-x86_64.tar.gz
+ln -s mysql-5.7.12-linux-glibc2.5-x86_64 5.7.12
+
+export SANDBOX_BINARY=$HOME/bins
+export SANDBOX_HOME=$HOME/sandboxes
+make_sandbox 5.7.12 -- --no_confirm --no_run
+
+CNF=$SANDBOX_HOME/msb_5_7_12/my.sandbox.cnf
+
+echo 'log-bin=mysql-bin'         | tee -a $CNF
+echo 'server-id=1'               | tee -a $CNF
+echo 'binlog-format =row'        | tee -a $CNF
+echo 'gtid_mode=ON'              | tee -a $CNF
+echo 'enforce_gtid_consistency'  | tee -a $CNF
+echo 'log_slave_updates'         | tee -a $CNF
+
+cat $CNF
+
+$SANDBOX_HOME/msb_5_7_12/start
+
+MYSQL=$SANDBOX_BINARY/5.7.12/bin/mysql
+$MYSQL --version
+$MYSQL -e 'SELECT VERSION();'
+# $MYSQL -u root -e "GRANT ALL PRIVILEGES ON *.* TO ''@'localhost';"
+$MYSQL -e 'CREATE DATABASE pymysqlreplication_test;'
+$MYSQL -e 'show variables;'
+

--- a/scripts/install_mysql_sandbox.sh
+++ b/scripts/install_mysql_sandbox.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -x
+
+apt-get install tree
+apt-get install libaio1
+
+curl -O http://www.cpan.org/authors/id/G/GM/GMAX/MySQL-Sandbox-3.1.05.tar.gz
+tar xfz MySQL-Sandbox-3.1.05.tar.gz
+cd MySQL-Sandbox-3.1.05
+perl Makefile.PL
+make install
+


### PR DESCRIPTION
With this patch tests can run on different mysql version (5.6 and 5.7). 
Some note about the patch:
- scripts directory store install script for different mysql version
- moved install instruction from .travis.yml to scripts/install_mysql56.sh
- scripts/install_mysql_sandbox.sh install [mysql_sandbox](http://mysqlsandbox.net/)
- script/install_mysql_57_on_sandbox.sh use mysql-sandbox to install mysql 5.7.12
- the env part define DB enviroment variable that decide on which mysql version test will be run

Travis run every combination from mysql version and python version.

The mysql_sandbox could be used to install other version (maybe 5.5). Using the sandbox is more generic that using the s.o. package manager and we can choice the exact version of mysql instead of the provided. version of the package maintainer.
