### PR TITLE
Fix the example: Add required server_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ from pymysqlreplication import BinLogStreamReader
 
 mysql_settings = {'host': '127.0.0.1', 'port': 3306, 'user': 'root', 'passwd': ''}
 
-stream = BinLogStreamReader(connection_settings = mysql_settings)
+stream = BinLogStreamReader(connection_settings = mysql_settings, server_id=100)
 
 for binlogevent in stream:
     binlogevent.dump()


### PR DESCRIPTION
Otherwise this happens:
```
Traceback (most recent call last):
  File "./test.py", line 6, in <module>
    stream = BinLogStreamReader(connection_settings = mysql_settings)
TypeError: __init__() missing 1 required positional argument: 'server_id'
```