### PR TITLE
use 0 as date/datetime zero value

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -250,13 +250,13 @@ class RowsEvent(BinLogEvent):
     def __read_date(self):
         time = self.packet.read_uint24()
         if time == 0:  # nasty mysql 0000-00-00 dates
-            return None
+            return 0
 
         year = (time & ((1 << 15) - 1) << 9) >> 9
         month = (time & ((1 << 4) - 1) << 5) >> 5
         day = (time & ((1 << 5) - 1))
         if year == 0 or month == 0 or day == 0:
-            return None
+            return 0
 
         date = datetime.date(
             year=year,
@@ -268,7 +268,7 @@ class RowsEvent(BinLogEvent):
     def __read_datetime(self):
         value = self.packet.read_uint64()
         if value == 0:  # nasty mysql 0000-00-00 dates
-            return None
+            return 0
 
         date = value / 1000000
         time = int(value % 1000000)
@@ -277,7 +277,7 @@ class RowsEvent(BinLogEvent):
         month = int((date % 10000) / 100)
         day = int(date % 100)
         if year == 0 or month == 0 or day == 0:
-            return None
+            return 0
 
         date = datetime.datetime(
             year=year,
@@ -311,7 +311,7 @@ class RowsEvent(BinLogEvent):
                 minute=self.__read_binary_slice(data, 28, 6, 40),
                 second=self.__read_binary_slice(data, 34, 6, 40))
         except ValueError:
-            return None
+            return 0
         return self.__add_fsp_to_time(t, column)
 
     def __read_new_decimal(self, column):


### PR DESCRIPTION
return 0 as zero value of date/datetime to tell difference from NULL and '0000-00-00'.
e.g. insert/update a NOT NULL date column, only '0000-00-00' or 0 is valid.