### PR TITLE
Decoupling table mapping to allow replaying all binlog events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ _build
 
 # Pyenv
 .python-version
+
+# Mac System files
+.DS_Store
+
+# Virtualenv folder
+env/

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
               "pymysqlreplication.tests"],
     cmdclass={"test": TestCommand},
     extras_require={'test': tests_require},
-    install_requires=['pymysql'],
+    install_requires=['pymysql', 'sqlparse'],
 )


### PR DESCRIPTION
As discussed in #56, starting a stream at a point in time where the schema of the source database was different than what it is now, will always break the program.

We can address this issue by allowing users of the library to set up a secondary MySQL database - a so-called Schema DB - and:
1. Catching all those QueryEvents that modify the underlying schema
2. Executing them on the Schema DB
3. Pointing the BinlogStreamReader's __get_table_information method to this DB's information schema.
