### PR TITLE
update doc to indicate privileges the user need

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,3 +4,9 @@ Examples
 
 You can found a list of working examples here: https://github.com/noplay/python-mysql-replication/tree/master/examples
 
+PREREQUISITES
+
+The user, you plan to use for the BinaryLogClient, must have REPLICATION SLAVE privilege. To get binlog filename and position, he must be granted at least one of REPLICATION CLIENT or SUPER as well. To get table info of mysql server, he also need SELECT privilege on information_schema.COLUMNS.
+We suggest grant below privileges to the user:
+
+:command:`GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'user'@'host'`


### PR DESCRIPTION
As I comment in #183 , it's import to add privilege introduction to avoid the misleading output, which also be reported in #116 , #131 and #172 .