### PR TITLE
Implement Heartbeat

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -70,6 +70,7 @@ class BinLogPacketWrapper(object):
         constants.STOP_EVENT: event.StopEvent,
         constants.BEGIN_LOAD_QUERY_EVENT: event.BeginLoadQueryEvent,
         constants.EXECUTE_LOAD_QUERY_EVENT: event.ExecuteLoadQueryEvent,
+        constants.HEARTBEAT_LOG_EVENT: event.HeartbeatLogEvent,
         # row_event
         constants.UPDATE_ROWS_EVENT_V1: row_event.UpdateRowsEvent,
         constants.WRITE_ROWS_EVENT_V1: row_event.WriteRowsEvent,

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -25,9 +25,9 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
         return [GtidEvent]
 
     def test_allowed_event_list(self):
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 13)
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 12)
-        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 12)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 14)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 13)
+        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 13)
         self.assertEqual(len(self.stream._allowed_event_list([RotateEvent], None, False)), 1)
 
     def test_read_query_event(self):
@@ -714,7 +714,8 @@ class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
 
         self.stream.close()
         self.stream = BinLogStreamReader(
-            self.database, server_id=1024, blocking=True, auto_position=gtid)
+            self.database, server_id=1024, blocking=True, auto_position=gtid,
+            ignored_events=[HeartbeatLogEvent])
 
         self.assertIsInstance(self.stream.fetchone(), RotateEvent)
         self.assertIsInstance(self.stream.fetchone(), FormatDescriptionEvent)
@@ -770,7 +771,8 @@ class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
 
         self.stream.close()
         self.stream = BinLogStreamReader(
-            self.database, server_id=1024, blocking=True, auto_position=gtid)
+            self.database, server_id=1024, blocking=True, auto_position=gtid,
+            ignored_events=[HeartbeatLogEvent])
 
         self.assertIsInstance(self.stream.fetchone(), RotateEvent)
         self.assertIsInstance(self.stream.fetchone(), FormatDescriptionEvent)


### PR DESCRIPTION
I ended up debugging a slow startup with pymysqlreplication,
the stream "stucked" for a few seconds before seeing first events coming in.
For that purpose I ended up implementing HeartbeatLogEvent and
documenting observed mysql behavior.

I also implemented the heartbeat feature, which is required for the mysqld
to filter events in gtid mode.