### PR TITLE
Add implementation of read_int32

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -282,6 +282,9 @@ class BinLogPacketWrapper(object):
     def read_uint32(self):
         return struct.unpack('<I', self.read(4))[0]
 
+    def read_int32(self):
+        return struct.unpack('<i', self.read(4))[0]
+
     def read_uint40(self):
         a, b = struct.unpack("<BI", self.read(5))
         return a + (b << 8)


### PR DESCRIPTION
This method is missing, but it is being called here: https://github.com/noplay/python-mysql-replication/blob/master/pymysqlreplication/packet.py#L358

This causes the replication to break when there is a 32-bit number in a JSON column.