### PR TITLE
Datetime3 read fails entire packet read

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -148,7 +148,8 @@ class BinLogStreamReader(object):
             log_file: Set replication start log file
             log_pos: Set replication start log pos (resume_stream should be true)
             auto_position: Use master_auto_position gtid to set position
-            only_tables: An array with the tables you want to watch
+            only_tables: An array with the tables you want to watch (only works
+                         in binlog_format ROW)
             ignored_tables: An array with the tables you want to skip
             only_schemas: An array with the schemas you want to watch
             ignored_schemas: An array with the schemas you want to skip

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -342,6 +342,7 @@ class RowsEvent(BinLogEvent):
                 minute=self.__read_binary_slice(data, 28, 6, 40),
                 second=self.__read_binary_slice(data, 34, 6, 40))
         except ValueError:
+            self.__read_fsp(column)
             return None
         return self.__add_fsp_to_time(t, column)
 


### PR DESCRIPTION
**only row_event.py changes are relevant**

**bug discription:** in some cases _fetch_one_row will result in some parsing error because of bad data packet read.
the miss read originated while reading datetime(3) rows. in cases where there was an error reading the datetime(3) from the packet the read function will return None and will skip reading the millisecond bytes, this will result in in an indentation of the packet reading, which will result error reading the rest of the packet.

**solution:** now the millisecond bytes will be trimmed in case of an error reading datetime(3) rows.