### PR TITLE
Datetime3 read fails entire packet read

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -342,6 +342,7 @@ class RowsEvent(BinLogEvent):
                 minute=self.__read_binary_slice(data, 28, 6, 40),
                 second=self.__read_binary_slice(data, 34, 6, 40))
         except ValueError:
+            self.__read_fsp(column)
             return None
         return self.__add_fsp_to_time(t, column)
 


### PR DESCRIPTION
**bug description:** in some cases _fetch_one_row will result in some parsing error because of bad data packet read.
the miss read originated while reading datetime(3) rows. in cases where there was an error reading the datetime(3) from the packet the read function will return None and will skip reading the millisecond bytes, this will result in in an indentation of the packet reading, which will result error reading the rest of the packet.

**solution:** now the millisecond bytes will be trimmed in case of an error reading datetime(3) rows.