### PR TITLE
Raise an explanatory exception when binary logging is not enabled. (Issue 185)

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -15,6 +15,7 @@ from .event import (
     XidEvent, GtidEvent, StopEvent,
     BeginLoadQueryEvent, ExecuteLoadQueryEvent,
     HeartbeatLogEvent, NotImplementedEvent)
+from .exceptions import BinLogNotEnabled
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
 
@@ -305,7 +306,10 @@ class BinLogStreamReader(object):
             if self.log_file is None or self.log_pos is None:
                 cur = self._stream_connection.cursor()
                 cur.execute("SHOW MASTER STATUS")
-                self.log_file, self.log_pos = cur.fetchone()[:2]
+                master_status = cur.fetchone()
+                if master_status is None:
+                    raise BinLogNotEnabled()
+                self.log_file, self.log_pos = master_status[:2]
                 cur.close()
 
             prelude = struct.pack('<i', len(self.log_file) + 11) \

--- a/pymysqlreplication/exceptions.py
+++ b/pymysqlreplication/exceptions.py
@@ -1,3 +1,8 @@
 class TableMetadataUnavailableError(Exception):
     def __init__(self, table):
         Exception.__init__(self,"Unable to find metadata for table {0}".format(table))
+
+
+class BinLogNotEnabled(Exception):
+    def __init__(self):
+        Exception.__init__(self, "MySQL binary loggging is not enabled.")


### PR DESCRIPTION
I was able to test by disabling binary logging on my local MySQL instance and running tests.  Certainly open to other suggestions as well. #185 