### PR TITLE
Add variable length JSON string support

### DIFF
--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -513,6 +513,16 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         event = self.create_and_insert_value(create_query, insert_query)
         self.assertEqual(event.rows[0]["values"]["value"][b"miam"], u'🍔'.encode('utf8'))
 
+    def test_json_long_string(self):
+        if not self.isMySQL57():
+            self.skipTest("Json is only supported in mysql 5.7")
+        create_query = "CREATE TABLE test (id int, value json);"
+        # The string length needs to be larger than what can fit in a single byte.
+        string_value = "super_long_string" * 100
+        insert_query = "INSERT INTO test (id, value) VALUES (1, '{\"my_key\": \"%s\"}');" % (string_value,)
+        event = self.create_and_insert_value(create_query, insert_query)
+        self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict({"my_key": string_value}))
+
     def test_null(self):
         create_query = "CREATE TABLE test ( \
             test TINYINT NULL DEFAULT NULL, \


### PR DESCRIPTION
The current implementation for reading a JSON string is incorrect and will fail to read strings longer than 127 characters. The test that I added in this branch confirms this. This correct implementation will handle longer strings according to the implementation in mysql-server and the included test passes with it.