### PR TITLE
fix column order

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -538,6 +538,7 @@ class BinLogStreamReader(object):
                         information_schema.columns
                     WHERE
                         table_schema = %s AND table_name = %s
+                    ORDER BY ORDINAL_POSITION
                     """, (schema, table))
 
                 return cur.fetchall()


### PR DESCRIPTION
From mysql docs https://dev.mysql.com/doc/refman/5.6/en/columns-table.html,

> ORDINAL_POSITION is necessary because you might want to say ORDER BY ORDINAL_POSITION.
> Unlike SHOW, SELECT does not have automatic ordering.