### PR TITLE
MySQL JSON field type with string should decode in python3

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -266,7 +266,7 @@ class BinLogPacketWrapper(object):
             byte = byte2int(self.read(1))
             length = length | ((byte & 0x7f) << bits_read)
             bits_read = bits_read + 7
-        return self.read(length).decode()
+        return self.read(length).decode('utf-8')
 
     def read_int24(self):
         a, b, c = struct.unpack("BBB", self.read(3))
@@ -429,7 +429,7 @@ class BinLogPacketWrapper(object):
         value_type_inlined_lengths = [read_offset_or_inline(self, large)
                                       for _ in range(elements)]
 
-        keys = [self.read(x[1]).decode() for x in key_offset_lengths]
+        keys = [self.read(x[1]).decode('utf-8') for x in key_offset_lengths]
 
         out = {}
         for i in range(elements):

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -266,7 +266,7 @@ class BinLogPacketWrapper(object):
             byte = byte2int(self.read(1))
             length = length | ((byte & 0x7f) << bits_read)
             bits_read = bits_read + 7
-        return self.read(length)
+        return self.read(length).decode()
 
     def read_int24(self):
         a, b, c = struct.unpack("BBB", self.read(3))
@@ -429,7 +429,7 @@ class BinLogPacketWrapper(object):
         value_type_inlined_lengths = [read_offset_or_inline(self, large)
                                       for _ in range(elements)]
 
-        keys = [self.read(x[1]) for x in key_offset_lengths]
+        keys = [self.read(x[1]).decode() for x in key_offset_lengths]
 
         out = {}
         for i in range(elements):

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -19,17 +19,6 @@ from pymysqlreplication._compat import text_type
 
 __all__ = ["TestDataType"]
 
-
-def to_binary_dict(d):
-    def encode_value(v):
-        if isinstance(v, text_type):
-            return v.encode()
-        if isinstance(v, list):
-            return [encode_value(x) for x in v]
-        return v
-    return dict([(k.encode(), encode_value(v)) for (k, v) in d.items()])
-
-
 class TestDataType(base.PyMySQLReplicationTestCase):
     def ignoredEvents(self):
         return [GtidEvent]
@@ -431,7 +420,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         create_query = "CREATE TABLE test (id int, value json);"
         insert_query = """INSERT INTO test (id, value) VALUES (1, '{"my_key": "my_val", "my_key2": "my_val2"}');"""
         event = self.create_and_insert_value(create_query, insert_query)
-        self.assertEqual(event.rows[0]["values"]["value"], {b"my_key": b"my_val", b"my_key2": b"my_val2"})
+        self.assertEqual(event.rows[0]["values"]["value"], {"my_key": "my_val", "my_key2": "my_val2"})
 
     def test_json_array(self):
         if not self.isMySQL57():
@@ -439,7 +428,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         create_query = "CREATE TABLE test (id int, value json);"
         insert_query = """INSERT INTO test (id, value) VALUES (1, '["my_val", "my_val2"]');"""
         event = self.create_and_insert_value(create_query, insert_query)
-        self.assertEqual(event.rows[0]["values"]["value"], [b'my_val', b'my_val2'])
+        self.assertEqual(event.rows[0]["values"]["value"], ['my_val', 'my_val2'])
 
     def test_json_large(self):
         if not self.isMySQL57():
@@ -449,7 +438,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         insert_query = """INSERT INTO test (id, value) VALUES (1, '%s');""" % json.dumps(data)
         event = self.create_and_insert_value(create_query, insert_query)
 
-        self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict(data))
+        self.assertEqual(event.rows[0]["values"]["value"], data)
 
     def test_json_types(self):
         if not self.isMySQL57():
@@ -474,7 +463,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
             create_query = "CREATE TABLE test (id int, value json);"
             insert_query = """INSERT INTO test (id, value) VALUES (1, '%s');""" % json.dumps(data)
             event = self.create_and_insert_value(create_query, insert_query)
-            self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict(data))
+            self.assertEqual(event.rows[0]["values"]["value"], data)
 
             self.tearDown()
             self.setUp()
@@ -511,7 +500,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         create_query = "CREATE TABLE test (id int, value json);"
         insert_query = u"""INSERT INTO test (id, value) VALUES (1, '{"miam": "🍔"}');"""
         event = self.create_and_insert_value(create_query, insert_query)
-        self.assertEqual(event.rows[0]["values"]["value"][b"miam"], u'🍔'.encode('utf8'))
+        self.assertEqual(event.rows[0]["values"]["value"]["miam"], u'🍔')
 
     def test_json_long_string(self):
         if not self.isMySQL57():
@@ -521,7 +510,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         string_value = "super_long_string" * 100
         insert_query = "INSERT INTO test (id, value) VALUES (1, '{\"my_key\": \"%s\"}');" % (string_value,)
         event = self.create_and_insert_value(create_query, insert_query)
-        self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict({"my_key": string_value}))
+        self.assertEqual(event.rows[0]["values"]["value"], {"my_key": string_value})
 
     def test_null(self):
         create_query = "CREATE TABLE test ( \


### PR DESCRIPTION
Fix #272 

Table:

`CREATE TABLE test (id int, value json);`

With data:

id | value 
---- | ----
1 | {"string1":"string2"}

But event's values in python3 is :

`{"id":1,"value":{b"string1":b"string2"}`

And when use `json.dumps` will raise `TypeError: keys must be a string`

According to rfc7159 : [https://tools.ietf.org/html/rfc7159#section-8.1](https://tools.ietf.org/html/rfc7159#section-8.1)

> JSON text SHALL be encoded in UTF-8, UTF-16, or UTF-32.  The default
   encoding is UTF-8

So should  decode as `utf-8` 