### PR TITLE
Insert NULL in a boolean column returns no rows #288

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -418,7 +418,7 @@ class RowsEvent(BinLogEvent):
         if not self.complete:
             return
 
-        while self.packet.read_bytes + 1 < self.event_size:
+        while self.packet.read_bytes < self.event_size:
             self.__rows.append(self._fetch_one_row())
 
     @property

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -169,6 +169,12 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         self.assertEqual(type(event.rows[0]["values"]["test"]), type(None))
         self.assertEqual(event.rows[0]["values"]["test"], None)
 
+    def test_tiny_maps_to_none_2(self):
+        create_query = "CREATE TABLE test (test BOOLEAN)"
+        insert_query = "INSERT INTO test VALUES(NULL)"
+        event = self.create_and_insert_value(create_query, insert_query)
+        self.assertEqual(event.rows[0]["values"]["test"], None)
+
     def test_short(self):
         create_query = "CREATE TABLE test (id SMALLINT UNSIGNED NOT NULL, test SMALLINT)"
         insert_query = "INSERT INTO test VALUES(65535, -32768)"


### PR DESCRIPTION
This fixes https://github.com/noplay/python-mysql-replication/issues/288