### PR TITLE
Support for limited columnar access in source MySQL

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -550,7 +550,7 @@ class BinLogStreamReader(object):
                 cur.execute("""
                     SELECT
                         COLUMN_NAME, COLLATION_NAME, CHARACTER_SET_NAME,
-                        COLUMN_COMMENT, COLUMN_TYPE, COLUMN_KEY
+                        COLUMN_COMMENT, COLUMN_TYPE, COLUMN_KEY, ORDINAL_POSITION
                     FROM
                         information_schema.columns
                     WHERE


### PR DESCRIPTION
- `GRANT SELECT <list-of-columns> ON <db>.<table> TO '<user>'@'%';` is possible now
- ORDINAL position of the column is used from `information_schema`.`columns` to figure out the columns to be dropped
- Dropped columns are mapped to `__dropped_col_<incremental-number>__`