### PR TITLE
Fix handling of JSON literal values #226 #298

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -43,9 +43,9 @@ def read_offset_or_inline(packet, large):
 
     if t in (JSONB_TYPE_LITERAL,
              JSONB_TYPE_INT16, JSONB_TYPE_UINT16):
-        return (t, None, packet.read_binary_json_type_inlined(t))
+        return (t, None, packet.read_binary_json_type_inlined(t, large))
     if large and t in (JSONB_TYPE_INT32, JSONB_TYPE_UINT32):
-        return (t, None, packet.read_binary_json_type_inlined(t))
+        return (t, None, packet.read_binary_json_type_inlined(t, large))
 
     if large:
         return (t, packet.read_uint32(), None)
@@ -255,7 +255,7 @@ class BinLogPacketWrapper(object):
     def read_variable_length_string(self):
         """Read a variable length string where the first 1-5 bytes stores the
         length of the string.
-        
+
         For each byte, the first bit being high indicates another byte must be
         read.
         """
@@ -384,9 +384,9 @@ class BinLogPacketWrapper(object):
 
         raise ValueError('Json type %d is not handled' % t)
 
-    def read_binary_json_type_inlined(self, t):
+    def read_binary_json_type_inlined(self, t, large):
         if t == JSONB_TYPE_LITERAL:
-            value = self.read_uint16()
+            value = self.read_uint32() if large else self.read_uint16()
             if value == JSONB_LITERAL_NULL:
                 return None
             elif value == JSONB_LITERAL_TRUE:

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -469,6 +469,16 @@ class TestDataType(base.PyMySQLReplicationTestCase):
 
         self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict(data))
 
+    def test_json_large_with_literal(self):
+        if not self.isMySQL57():
+            self.skipTest("Json is only supported in mysql 5.7")
+        data = dict([('foooo%i'%i, 'baaaaar%i'%i) for i in range(2560)], literal=True)  # Make it large with literal
+        create_query = "CREATE TABLE test (id int, value json);"
+        insert_query = """INSERT INTO test (id, value) VALUES (1, '%s');""" % json.dumps(data)
+        event = self.create_and_insert_value(create_query, insert_query)
+
+        self.assertEqual(event.rows[0]["values"]["value"], to_binary_dict(data))
+
     def test_json_types(self):
         if not self.isMySQL57():
             self.skipTest("Json is only supported in mysql 5.7")


### PR DESCRIPTION
In case of large JSON documents, literal values should be retrieved with
`read_uint32` instead of `read_uint32` to avoid further AssertionError:

```
To compensate for the extra space needed by the redundant length
information, we will make the format allow offset and length fields to
come in two different variants: 2 bytes for documents smaller than
64KB, and 4 bytes to support larger documents.
```
https://dev.mysql.com/worklog/task/?id=8132