### PR TITLE
make json parsing faster by reading it from socket instead of memory

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -345,8 +345,6 @@ class BinLogPacketWrapper(object):
 
     def read_binary_json(self, size):
         length = self.read_uint_by_size(size)
-        payload = self.read(length)
-        self.unread(payload)
         t = self.read_uint8()
 
         return self.read_binary_json_type(t, length)


### PR DESCRIPTION
large JSON binary structs are parsed slowly since they are read from memory and not from socket. i believe these lines were used to debug the JSON payload but were not removed