### PR TITLE
Add logic to handle inlined ints in large json documents

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -394,13 +394,13 @@ class BinLogPacketWrapper(object):
             elif value == JSONB_LITERAL_FALSE:
                 return False
         elif t == JSONB_TYPE_INT16:
-            return self.read_int16()
+            return self.read_int32() if large else self.read_int16()
         elif t == JSONB_TYPE_UINT16:
-            return self.read_uint16()
+            return self.read_uint32() if large else self.read_uint16()
         elif t == JSONB_TYPE_INT32:
-            return self.read_int32()
+            return self.read_int64() if large else self.read_int32()
         elif t == JSONB_TYPE_UINT32:
-            return self.read_uint32()
+            return self.read_uint64() if large else self.read_uint32()
 
         raise ValueError('Json type %d is not handled' % t)
 


### PR DESCRIPTION
This PR fixes a bug when handling inlined ints in "large" JSON documents. When attempting to read these values, the incorrect length was used causing some cascading failures downstream trying to parse the bin logs.

Reading the correct lengths for these data types within large JSON documents resolved the issue. 

This is related to https://github.com/noplay/python-mysql-replication/pull/307