### PR TITLE
docs: fix simple typo, datebases -> databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Projects using this library
 * ElasticMage: Full Magento integration with ElasticSearch https://github.com/ElasticMage/elasticmage
 * Cache buster: an automatic cache invalidation system https://github.com/rackerlabs/cache-busters
 * Zabbix collector for OpenTSDB https://github.com/OpenTSDB/tcollector/blob/master/collectors/0/zabbix_bridge.py
-* Meepo: Event sourcing and event broadcasting for datebases. https://github.com/eleme/meepo
+* Meepo: Event sourcing and event broadcasting for databases. https://github.com/eleme/meepo
 * Python MySQL Replication Blinker: This package read events from MySQL binlog and send to blinker's signal. https://github.com/tarzanjw/python-mysql-replication-blinker
 * aiomysql_replication: Fork supporting asyncio https://github.com/jettify/aiomysql_replication
 * python-mysql-eventprocessor: Daemon interface for handling MySQL binary log events. https://github.com/jffifa/python-mysql-eventprocessor


### PR DESCRIPTION
There is a small typo in README.md.

Should read `databases` rather than `datebases`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md