### PR TITLE
Removed pymysql.util function ( byte2int, int2byte )

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -6,7 +6,6 @@ from distutils.version import LooseVersion
 
 from pymysql.constants.COMMAND import COM_BINLOG_DUMP, COM_REGISTER_SLAVE
 from pymysql.cursors import DictCursor
-from pymysql.util import int2byte
 
 from .packet import BinLogPacketWrapper
 from .constants.BINLOG import TABLE_MAP_EVENT, ROTATE_EVENT
@@ -109,7 +108,7 @@ class ReportSlave(object):
         MAX_STRING_LEN = 257  # one byte for length + 256 chars
 
         return (struct.pack('<i', packet_len) +
-                int2byte(COM_REGISTER_SLAVE) +
+                bytes([COM_REGISTER_SLAVE]) +
                 struct.pack('<L', server_id) +
                 struct.pack('<%dp' % min(MAX_STRING_LEN, lhostname + 1),
                             self.hostname.encode()) +
@@ -321,7 +320,7 @@ class BinLogStreamReader(object):
                 cur.close()
 
             prelude = struct.pack('<i', len(self.log_file) + 11) \
-                + int2byte(COM_BINLOG_DUMP)
+                + bytes([COM_BINLOG_DUMP])
 
             if self.__resume_stream:
                 prelude += struct.pack('<I', self.log_pos)
@@ -382,7 +381,7 @@ class BinLogStreamReader(object):
                            4)  # encoded_data_size
 
             prelude = b'' + struct.pack('<i', header_size + encoded_data_size)\
-                + int2byte(COM_BINLOG_DUMP_GTID)
+                + bytes([COM_BINLOG_DUMP_GTID])
 
             flags = 0
             if not self.__blocking:

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -2,8 +2,6 @@
 
 import struct
 
-from pymysql.util import byte2int
-
 from pymysqlreplication import constants, event, row_event
 
 # Constants from PyMYSQL source code
@@ -111,7 +109,7 @@ class BinLogPacketWrapper(object):
 
         # Header
         self.timestamp = unpack[1]
-        self.event_type = byte2int(unpack[2])
+        self.event_type = unpack[2]
         self.server_id = unpack[3]
         self.event_size = unpack[4]
         # position of the next event
@@ -178,7 +176,7 @@ class BinLogPacketWrapper(object):
 
         From PyMYSQL source code
         """
-        c = byte2int(self.read(1))
+        c = self.read(1)[0]
         if c == NULL_COLUMN:
             return None
         if c < UNSIGNED_CHAR_COLUMN:
@@ -263,7 +261,7 @@ class BinLogPacketWrapper(object):
         length = 0
         bits_read = 0
         while byte & 0x80 != 0:
-            byte = byte2int(self.read(1))
+            byte = self.read(1)[0]
             length = length | ((byte & 0x7f) << bits_read)
             bits_read = bits_read + 7
         return self.read(length)

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -5,7 +5,6 @@ import decimal
 import datetime
 import json
 
-from pymysql.util import byte2int
 from pymysql.charset import charset_by_name
 
 from .event import BinLogEvent
@@ -556,10 +555,10 @@ class TableMapEvent(BinLogEvent):
         self.flags = struct.unpack('<H', self.packet.read(2))[0]
 
         # Payload
-        self.schema_length = byte2int(self.packet.read(1))
+        self.schema_length = self.packet.read(1)[0]
         self.schema = self.packet.read(self.schema_length).decode()
         self.packet.advance(1)
-        self.table_length = byte2int(self.packet.read(1))
+        self.table_length = self.packet.read(1)[0]
         self.table = self.packet.read(self.table_length).decode()
 
         if self.__only_tables is not None and self.table not in self.__only_tables:
@@ -617,7 +616,7 @@ class TableMapEvent(BinLogEvent):
                         'COLUMN_TYPE': 'BLOB',  # we don't know what it is, so let's not do anything with it.
                         'COLUMN_KEY': '',
                     }
-                col = Column(byte2int(column_type), column_schema, from_packet)
+                col = Column(column_type, column_schema, from_packet)
                 self.columns.append(col)
 
         self.table_obj = Table(self.column_schemas, self.table_id, self.schema,

--- a/pymysqlreplication/tests/binlogfilereader.py
+++ b/pymysqlreplication/tests/binlogfilereader.py
@@ -1,7 +1,6 @@
 '''Read binlog files'''
 import struct
 
-from pymysql.util import byte2int
 from pymysqlreplication import constants
 from pymysqlreplication.event import FormatDescriptionEvent
 from pymysqlreplication.event import QueryEvent
@@ -113,7 +112,7 @@ class SimpleBinLogEvent(object):
         '''Initialize the Event with the event header'''
         unpacked = struct.unpack('<IcIIIH', header)
         self.timestamp = unpacked[0]
-        self.event_type = byte2int(unpacked[1])
+        self.event_type = unpacked[1]
         self.server_id = unpacked[2]
         self.event_size = unpacked[3]
         self.log_pos = unpacked[4]

--- a/pymysqlreplication/tests/binlogfilereader.py
+++ b/pymysqlreplication/tests/binlogfilereader.py
@@ -112,7 +112,7 @@ class SimpleBinLogEvent(object):
         '''Initialize the Event with the event header'''
         unpacked = struct.unpack('<IcIIIH', header)
         self.timestamp = unpacked[0]
-        self.event_type = unpacked[1]
+        self.event_type = unpacked[1][0]
         self.server_id = unpacked[2]
         self.event_size = unpacked[3]
         self.log_pos = unpacked[4]


### PR DESCRIPTION
`byte2int`, `int2byte` removed at PyMySQL>=1.0.0 in `pymysql.util`

https://github.com/PyMySQL/PyMySQL/pull/923/files