### PR TITLE
Fix typo in pymysqlreplication/row_event.py

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -532,7 +532,7 @@ class UpdateRowsEvent(RowsEvent):
 
 
 class TableMapEvent(BinLogEvent):
-    """This evenement describe the structure of a table.
+    """This event describes the structure of a table.
     It's sent before a change happens on a table.
     An end user of the lib should have no usage of this
     """


### PR DESCRIPTION
I found a trivial typo in [pymysqlreplication/row_event.py:535](https://github.com/noplay/python-mysql-replication/blob/f73e0a1b70b71875d8418c96d5755b8329a45f26/pymysqlreplication/row_event.py#L535-L537)

https://github.com/noplay/python-mysql-replication/blob/f73e0a1b70b71875d8418c96d5755b8329a45f26/pymysqlreplication/row_event.py#L535-L538

'This evenement describe'->'This event describes'