### PR TITLE
Add pymysql 1.0 support

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -6,7 +6,6 @@ from distutils.version import LooseVersion
 
 from pymysql.constants.COMMAND import COM_BINLOG_DUMP, COM_REGISTER_SLAVE
 from pymysql.cursors import DictCursor
-from pymysql.util import int2byte
 
 from .packet import BinLogPacketWrapper
 from .constants.BINLOG import TABLE_MAP_EVENT, ROTATE_EVENT
@@ -109,7 +108,7 @@ class ReportSlave(object):
         MAX_STRING_LEN = 257  # one byte for length + 256 chars
 
         return (struct.pack('<i', packet_len) +
-                int2byte(COM_REGISTER_SLAVE) +
+                bytes(bytearray([COM_REGISTER_SLAVE])) +
                 struct.pack('<L', server_id) +
                 struct.pack('<%dp' % min(MAX_STRING_LEN, lhostname + 1),
                             self.hostname.encode()) +
@@ -321,7 +320,7 @@ class BinLogStreamReader(object):
                 cur.close()
 
             prelude = struct.pack('<i', len(self.log_file) + 11) \
-                + int2byte(COM_BINLOG_DUMP)
+                + bytes(bytearray([COM_BINLOG_DUMP]))
 
             if self.__resume_stream:
                 prelude += struct.pack('<I', self.log_pos)
@@ -382,7 +381,7 @@ class BinLogStreamReader(object):
                            4)  # encoded_data_size
 
             prelude = b'' + struct.pack('<i', header_size + encoded_data_size)\
-                + int2byte(COM_BINLOG_DUMP_GTID)
+                + bytes(bytearray([COM_BINLOG_DUMP_GTID]))
 
             flags = 0
             if not self.__blocking:

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -4,8 +4,6 @@ import binascii
 import struct
 import datetime
 
-from pymysql.util import byte2int, int2byte
-
 
 class BinLogEvent(object):
     def __init__(self, from_packet, event_size, table_map, ctl_connection,
@@ -30,7 +28,7 @@ class BinLogEvent(object):
     def _read_table_id(self):
         # Table ID is 6 byte
         # pad little-endian number
-        table_id = self.packet.read(6) + int2byte(0) + int2byte(0)
+        table_id = self.packet.read(6) + b"\x00\x00"
         return struct.unpack('<Q', table_id)[0]
 
     def dump(self):
@@ -55,7 +53,7 @@ class GtidEvent(BinLogEvent):
         super(GtidEvent, self).__init__(from_packet, event_size, table_map,
                                           ctl_connection, **kwargs)
 
-        self.commit_flag = byte2int(self.packet.read(1)) == 1
+        self.commit_flag = struct.unpack("!B", self.packet.read(1))[0] == 1
         self.sid = self.packet.read(16)
         self.gno = struct.unpack('<Q', self.packet.read(8))[0]
 
@@ -164,7 +162,7 @@ class QueryEvent(BinLogEvent):
         # Post-header
         self.slave_proxy_id = self.packet.read_uint32()
         self.execution_time = self.packet.read_uint32()
-        self.schema_length = byte2int(self.packet.read(1))
+        self.schema_length = struct.unpack("!B", self.packet.read(1))[0]
         self.error_code = self.packet.read_uint16()
         self.status_vars_length = self.packet.read_uint16()
 

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -2,8 +2,6 @@
 
 import struct
 
-from pymysql.util import byte2int
-
 from pymysqlreplication import constants, event, row_event
 
 # Constants from PyMYSQL source code
@@ -107,11 +105,11 @@ class BinLogPacketWrapper(object):
         # server_id
         # log_pos
         # flags
-        unpack = struct.unpack('<cIcIIIH', self.packet.read(20))
+        unpack = struct.unpack('<cIBIIIH', self.packet.read(20))
 
         # Header
         self.timestamp = unpack[1]
-        self.event_type = byte2int(unpack[2])
+        self.event_type = unpack[2]
         self.server_id = unpack[3]
         self.event_size = unpack[4]
         # position of the next event
@@ -178,7 +176,7 @@ class BinLogPacketWrapper(object):
 
         From PyMYSQL source code
         """
-        c = byte2int(self.read(1))
+        c = struct.unpack("!B", self.read(1))[0]
         if c == NULL_COLUMN:
             return None
         if c < UNSIGNED_CHAR_COLUMN:
@@ -263,7 +261,7 @@ class BinLogPacketWrapper(object):
         length = 0
         bits_read = 0
         while byte & 0x80 != 0:
-            byte = byte2int(self.read(1))
+            byte = struct.unpack("!B", self.read(1))[0]
             length = length | ((byte & 0x7f) << bits_read)
             bits_read = bits_read + 7
         return self.read(length)

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -5,7 +5,6 @@ import decimal
 import datetime
 import json
 
-from pymysql.util import byte2int
 from pymysql.charset import charset_by_name
 
 from .event import BinLogEvent
@@ -556,10 +555,10 @@ class TableMapEvent(BinLogEvent):
         self.flags = struct.unpack('<H', self.packet.read(2))[0]
 
         # Payload
-        self.schema_length = byte2int(self.packet.read(1))
+        self.schema_length = struct.unpack("!B", self.packet.read(1))[0]
         self.schema = self.packet.read(self.schema_length).decode()
         self.packet.advance(1)
-        self.table_length = byte2int(self.packet.read(1))
+        self.table_length = struct.unpack("!B", self.packet.read(1))[0]
         self.table = self.packet.read(self.table_length).decode()
 
         if self.__only_tables is not None and self.table not in self.__only_tables:
@@ -590,7 +589,7 @@ class TableMapEvent(BinLogEvent):
 
         if len(self.column_schemas) != 0:
             # Read columns meta data
-            column_types = list(self.packet.read(self.column_count))
+            column_types = bytearray(self.packet.read(self.column_count))
             self.packet.read_length_coded_binary()
             for i in range(0, len(column_types)):
                 column_type = column_types[i]
@@ -617,7 +616,7 @@ class TableMapEvent(BinLogEvent):
                         'COLUMN_TYPE': 'BLOB',  # we don't know what it is, so let's not do anything with it.
                         'COLUMN_KEY': '',
                     }
-                col = Column(byte2int(column_type), column_schema, from_packet)
+                col = Column(column_type, column_schema, from_packet)
                 self.columns.append(col)
 
         self.table_obj = Table(self.column_schemas, self.table_id, self.schema,

--- a/pymysqlreplication/tests/binlogfilereader.py
+++ b/pymysqlreplication/tests/binlogfilereader.py
@@ -1,7 +1,6 @@
 '''Read binlog files'''
 import struct
 
-from pymysql.util import byte2int
 from pymysqlreplication import constants
 from pymysqlreplication.event import FormatDescriptionEvent
 from pymysqlreplication.event import QueryEvent
@@ -111,9 +110,9 @@ class SimpleBinLogEvent(object):
 
     def __init__(self, header):
         '''Initialize the Event with the event header'''
-        unpacked = struct.unpack('<IcIIIH', header)
+        unpacked = struct.unpack('<IBIIIH', header)
         self.timestamp = unpacked[0]
-        self.event_type = byte2int(unpacked[1])
+        self.event_type = unpacked[1]
         self.server_id = unpacked[2]
         self.event_size = unpacked[3]
         self.log_pos = unpacked[4]


### PR DESCRIPTION
pymysql>=1.0 removed pymysql.util.
https://github.com/PyMySQL/PyMySQL/pull/923

replaced bytes2int, int2byte in py23 compatible manner.

There is #337 that aims to fix the same issue.
Another patch is #346 for int2byte part.

Tested `setup.py test` with docker percona instances as in docs.
