### PR TITLE
Fix typo in pymysqlreplication/gtid.py

### DIFF
--- a/pymysqlreplication/gtid.py
+++ b/pymysqlreplication/gtid.py
@@ -16,7 +16,7 @@ class Gtid(object):
     intervals [a,b), and represent all transactions x that happened on
     server SID such as
 
-        x <= a < b
+        a <= x < b
 
     The human representation of it, though, is either represented by a
     single transaction number A=a (when only one transaction is covered,


### PR DESCRIPTION
I found a trivial typo in [pymysqlreplication/gtid.py:19](https://github.com/noplay/python-mysql-replication/blob/f73e0a1b70b71875d8418c96d5755b8329a45f26/pymysqlreplication/gtid.py#L19)

https://github.com/noplay/python-mysql-replication/blob/f73e0a1b70b71875d8418c96d5755b8329a45f26/pymysqlreplication/gtid.py#L15-L19

'x <= a < b' -> 'a <= x < b'