### PR TITLE
Correct timedelta value for negative MySQL TIME datatype

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -285,11 +285,11 @@ class RowsEvent(BinLogEvent):
             data = ~data + 1
 
         t = datetime.timedelta(
-            hours=sign*self.__read_binary_slice(data, 2, 10, 24),
+            hours=self.__read_binary_slice(data, 2, 10, 24),
             minutes=self.__read_binary_slice(data, 12, 6, 24),
             seconds=self.__read_binary_slice(data, 18, 6, 24),
             microseconds=self.__read_fsp(column)
-        )
+        ) * sign
         return t
 
     def __read_date(self):

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -291,7 +291,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
             microseconds=(((838*60) + 59)*60 + 59)*1000000
         ))
         self.assertEqual(event.rows[0]["values"]["test2"], datetime.timedelta(
-            microseconds=(((-838*60) + 59)*60 + 59)*1000000
+            microseconds=-(((838*60) + 59)*60 + 59)*1000000
         ))
 
     def test_time2(self):
@@ -306,7 +306,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
             microseconds=(((838*60) + 59)*60 + 59)*1000000 + 0
         ))
         self.assertEqual(event.rows[0]["values"]["test2"], datetime.timedelta(
-            microseconds=(((-838*60) + 59)*60 + 59)*1000000 + 0
+            microseconds=-(((838*60) + 59)*60 + 59)*1000000 + 0
         ))
 
     def test_zero_time(self):


### PR DESCRIPTION
1. minimum value for MySQL TIME datatype:
'-838:59:59.000000' = ADDTIME('-838:00:00', ADDTIME('-00:59:00', '-00:00:59'))

2. appropriate timedelta representation of the same value in Python:
datetime.timedelta(hours=-838, minutes=-59, seconds=-59)
= -1 * datetime.timedelta(hours=838, minutes=59, seconds=59)

'sign' must be multiplied to the entire timedelta,
not just to the 'hours' timedelta as in the existing code.
https://github.com/noplay/python-mysql-replication/blob/3de6ff499f7695a800409341f4f859cac5b724d0/pymysqlreplication/row_event.py#L287-L292

refer to convert_timedelta() in pymysql:
https://github.com/PyMySQL/PyMySQL/blob/fb10477caf21122a89d7f216a0670d49dd2aa5d2/pymysql/converters.py#L219-L227

Datatype tests were modified to test the correct minimum value for TIME datatype.