### PR TITLE
Fix parsing of row events for MySQL8 partitioned table

### DIFF
--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -59,15 +59,20 @@ class RowsEvent(BinLogEvent):
                 self.flags, self.extra_data_length = struct.unpack('<HH', self.packet.read(4))
                 if self.extra_data_length > 2:
                     self.extra_data_type = struct.unpack('<B', self.packet.read(1))[0]
+
+                    # ndb information
+                    if self.extra_data_type == 0:
+                        self.nbd_info_length, self.nbd_info_format = struct.unpack('<BB', self.packet.read(1))
+                        self.nbd_info = self.packet.read(self.nbd_info_length - 2)
                     # partition information
-                    if self.extra_data_type == 1:
+                    elif self.extra_data_type == 1:
                         if self.event_type == BINLOG.UPDATE_ROWS_EVENT_V2:
                             self.partition_id, self.source_partition_id = struct.unpack('<HH', self.packet.read(4))
                         else:
                             self.partition_id = struct.unpack('<H', self.packet.read(2))[0]
-                    # NDB information etc.
+                    # etc
                     else:
-                        self.extra_data = self.packet.read(self.extra_data_length - 3)
+                        self.extra_data = self.packet.read(self.extra_info_length - 3)
         else:
             self.flags = struct.unpack('<H', self.packet.read(2))[0]
 

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -60,6 +60,10 @@ class PyMySQLReplicationTestCase(base):
         version = float(self.getMySQLVersion().rsplit('.', 1)[0])
         return version == 5.7
 
+    def isMySQL80AndMore(self):
+        version = float(self.getMySQLVersion().rsplit('.', 1)[0])
+        return version >= 8.0
+
     @property
     def supportsGTID(self):
         if not self.isMySQL56AndMore():

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -625,5 +625,21 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         self.assertEqual(event.rows[0]["values"]["test4"], '0000000001')
         self.assertEqual(event.rows[0]["values"]["test5"], '00000000000000000001')
 
+    def test_extra_data(self):
+        if not self.isMySQL80AndMore():
+            self.skipTest("Not supported in this version of MySQL")
+        create_query = "CREATE TABLE test (id INTEGER) \
+            PARTITION BY RANGE (id) ( \
+                PARTITION p0 VALUES LESS THAN (1),   \
+                PARTITION p1 VALUES LESS THAN (2),   \
+                PARTITION p2 VALUES LESS THAN (3),   \
+                PARTITION p3 VALUES LESS THAN (4),   \
+                PARTITION p4 VALUES LESS THAN (5),   \
+            )"
+        insert_query = "INSERT INTO test (id) VALUES(3)"
+        event = self.create_and_insert_value(create_query, insert_query)
+        self.assertEqual(event.extra_data_type, 1)
+        self.assertEqual(event.partition_id, 3)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -625,7 +625,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
         self.assertEqual(event.rows[0]["values"]["test4"], '0000000001')
         self.assertEqual(event.rows[0]["values"]["test5"], '00000000000000000001')
 
-    def test_extra_data(self):
+    def test_partition_id(self):
         if not self.isMySQL80AndMore():
             self.skipTest("Not supported in this version of MySQL")
         create_query = "CREATE TABLE test (id INTEGER) \

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -634,7 +634,7 @@ class TestDataType(base.PyMySQLReplicationTestCase):
                 PARTITION p1 VALUES LESS THAN (2),   \
                 PARTITION p2 VALUES LESS THAN (3),   \
                 PARTITION p3 VALUES LESS THAN (4),   \
-                PARTITION p4 VALUES LESS THAN (5),   \
+                PARTITION p4 VALUES LESS THAN (5)    \
             )"
         insert_query = "INSERT INTO test (id) VALUES(3)"
         event = self.create_and_insert_value(create_query, insert_query)


### PR DESCRIPTION
Since MySQL 8.0.16, partition info has been [added](https://github.com/mysql/mysql-server/commit/e11a540fc559dfbed72ba4ec4677638ac917454f) into extra_data in row event.

Current code is aware of extra_data but doesn't parse it accurately. The program reads `extra_data_length / 8` bytes from packet instead of `extra_data_length - 2` of correct byte-length. This leads the program to **skip parsing of extra_data**.

In some cases errors occur, and in other cases parse result shows incorrect field values as in [issue #354](https://github.com/noplay/python-mysql-replication/issues/354#issue-971136865). (**undefined behavior**) 

below are the modifications made:
1. **Correct byte-length of extra_data** to conform to replication protocol
    `extra_data_length / 8` -> `extra_data_length - 2`
    * AS-IS:
https://github.com/noplay/python-mysql-replication/blob/3de6ff499f7695a800409341f4f859cac5b724d0/pymysqlreplication/row_event.py#L60
     * TO-BE
![image](https://user-images.githubusercontent.com/29939301/130363876-28cce3bd-1e49-4c81-9e41-7ea10022bad1.png)
    Refer to [MySQL Document](https://dev.mysql.com/doc/internals/en/rows-event.html) and [MySQL source code](https://github.com/mysql/mysql-server/blob/beb865a960b9a8a16cf999c323e46c5b0c67f21f/libbinlogevents/src/rows_event.cpp#L415) for correct bytes-to-read.

2. **Parse extra_data** according to [extra_data layout](https://github.com/mysql/mysql-server/blob/beb865a960b9a8a16cf999c323e46c5b0c67f21f/libbinlogevents/include/rows_event.h#L772-L814) to get partition id ( or ndb info)

```
        +----------+--------------------------------------+
        |type_code |        extra_row_ndb_info            |
        +--- ------+--------------------------------------+
        | NDB      |Len of ndb_info |Format |ndb_data     |
        | 1 byte   |1 byte          |1 byte |len - 2 byte |
        +----------+----------------+-------+-------------+

        In case of INSERT/DELETE
        +-----------+----------------+
        | type_code | partition_info |
        +-----------+----------------+
        |   PART    |  partition_id  |
        | (1 byte)  |     2 byte     |
        +-----------+----------------+

        In case of UPDATE
        +-----------+------------------------------------+
        | type_code |        partition_info              |
        +-----------+--------------+---------------------+
        |   PART    | partition_id | source_partition_id |
        | (1 byte)  |    2 byte    |       2 byte        |
        +-----------+--------------+---------------------+
```

3. **data type tests were added** to test parsing of extra_data, and correct value of prtition_id