### PR TITLE
To fix ValueError: Json type 96 is not handled

### DIFF
--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -343,6 +343,9 @@ class BinLogPacketWrapper(object):
 
     def read_binary_json(self, size):
         length = self.read_uint_by_size(size)
+        if length == 0:
+            # handle NULL value
+            return None
         payload = self.read(length)
         self.unread(payload)
         t = self.read_uint8()


### PR DESCRIPTION
To handle for Null value for the JSON data type.

The following snippet is the traceback for when the payload is empty/null. Example of scenario is when the column allowed nullable.

```
Traceback (most recent call last):
  File "b.py", line 106, in <module>
    binlog_event.event.dump()
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/event.py", line 42, in dump
    self._dump()
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/row_event.py", line 548, in _dump
    super(UpdateRowsEvent, self)._dump()
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/row_event.py", line 444, in _dump
    print("Changed rows: %d" % (len(self.rows)))
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/row_event.py", line 458, in rows
    self._fetch_rows()
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/row_event.py", line 453, in _fetch_rows
    self.__rows.append(self._fetch_one_row())
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/row_event.py", line 542, in _fetch_one_row
    row["before_values"] = self._read_column_data(self.columns_present_bitmap)
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/row_event.py", line 206, in _read_column_data
    values[name] = self.packet.read_binary_json(column.length_size)
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/packet.py", line 350, in read_binary_json
    return self.read_binary_json_type(t, length)
  File "/Users/mahadirahmad/opt/anaconda3/envs/analytics/lib/python3.6/site-packages/pymysqlreplication/packet.py", line 383, in read_binary_json_type
    raise ValueError('Json type %d is not handled' % t)
ValueError: Json type 96 is not handled
```